### PR TITLE
feat(create): パスワード入力フォーム追加 #21

### DIFF
--- a/src/app/create/create.module.ts
+++ b/src/app/create/create.module.ts
@@ -3,14 +3,15 @@ import { CommonModule } from '@angular/common';
 
 import { CreateRoutingModule } from './create-routing.module';
 import { CreateComponent } from './create/create.component';
-import { MatToolbarModule } from '@angular/material/toolbar';
 // フォームを使うためにimportさせるModule
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatButtonModule } from '@angular/material/button';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
+import { MatIconModule } from '@angular/material/icon';
 
 @NgModule({
   declarations: [CreateComponent],
@@ -24,7 +25,8 @@ import { MatSelectModule } from '@angular/material/select';
     MatFormFieldModule,
     MatButtonModule,
     MatRadioModule,
-    MatSelectModule
+    MatSelectModule,
+    MatIconModule
   ]
 })
 export class CreateModule {}

--- a/src/app/create/create/create.component.html
+++ b/src/app/create/create/create.component.html
@@ -68,9 +68,32 @@
           autocomplete="email"
           required
         />
-
         <mat-error></mat-error>
       </mat-form-field>
+      <br />
+
+      <!-- password -->
+      <mat-form-field>
+        <mat-label>password</mat-label>
+        <input
+          type="hide ? 'password' : text"
+          matInput
+          placeholder="password"
+          id="password"
+          formControlName="password"
+          required
+        />
+        <button
+          mat-icon-button
+          matSuffix
+          (click)="hide = !hide"
+          [attr.aria-label]="'Hide password'"
+          [attr.aria-pressed]="hide"
+        >
+          <mat-icon>{{ hide ? 'visibility_off' : 'visibility' }}</mat-icon>
+        </button>
+      </mat-form-field>
+      <br />
 
       <button mat-raised-button color="primary">
         Next

--- a/src/app/create/create/create.component.html
+++ b/src/app/create/create/create.component.html
@@ -64,8 +64,8 @@
           id="email"
           matInput
           placeholder="WorkOut123@example.com"
-          type="text"
-          autocomplete="off"
+          type="type"
+          autocomplete="email"
           required
         />
 

--- a/src/app/create/create/create.component.ts
+++ b/src/app/create/create/create.component.ts
@@ -10,6 +10,7 @@ import { FormBuilder, Validators, FormControl } from '@angular/forms';
 // ModuleでimportしたFormを画面上で使うためにComponentで定義するためにbuildして作る
 //   constructorの中に使いたい機能を定義
 export class CreateComponent implements OnInit {
+  hide = true;
   form = this.fb.group({
     name: [
       '',


### PR DESCRIPTION
アカウント作成画面でのパスワード入力フォームを追加しました。
確認お願いいたします。
<img width="151" alt="コメント 2020-04-14 142720" src="https://user-images.githubusercontent.com/60285013/79189205-1c977380-7e5c-11ea-9d45-f103eeed5ec1.png">
