### PR TITLE
feat(create): 確認用パスワード入力フォーム追加 #20

### DIFF
--- a/src/app/create/create.module.ts
+++ b/src/app/create/create.module.ts
@@ -3,14 +3,15 @@ import { CommonModule } from '@angular/common';
 
 import { CreateRoutingModule } from './create-routing.module';
 import { CreateComponent } from './create/create.component';
-import { MatToolbarModule } from '@angular/material/toolbar';
 // フォームを使うためにimportさせるModule
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatButtonModule } from '@angular/material/button';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
+import { MatIconModule } from '@angular/material/icon';
 
 @NgModule({
   declarations: [CreateComponent],
@@ -24,7 +25,8 @@ import { MatSelectModule } from '@angular/material/select';
     MatFormFieldModule,
     MatButtonModule,
     MatRadioModule,
-    MatSelectModule
+    MatSelectModule,
+    MatIconModule
   ]
 })
 export class CreateModule {}

--- a/src/app/create/create/create.component.html
+++ b/src/app/create/create/create.component.html
@@ -64,7 +64,7 @@
           id="email"
           matInput
           placeholder="WorkOut123@example.com"
-          type="type"
+          type="email"
           autocomplete="email"
           required
         />

--- a/src/app/create/create/create.component.html
+++ b/src/app/create/create/create.component.html
@@ -68,9 +68,32 @@
           autocomplete="email"
           required
         />
-
         <mat-error></mat-error>
       </mat-form-field>
+      <br />
+
+      <!-- password -->
+      <mat-form-field>
+        <mat-label>password</mat-label>
+        <input
+          type="hide ? 'password' : text"
+          matInput
+          placeholder="password"
+          id="password"
+          formControlName="password"
+          required
+        />
+        <button
+          mat-icon-button
+          matSuffix
+          (click)="hide = !hide"
+          [attr.aria-label]="'Hide password'"
+          [attr.aria-pressed]="hide"
+        >
+          <mat-icon>{{ hide ? 'visibility_off' : 'visibility' }}</mat-icon>
+        </button>
+      </mat-form-field>
+      <br />
 
       <button mat-raised-button color="primary">
         Next

--- a/src/app/create/create/create.component.html
+++ b/src/app/create/create/create.component.html
@@ -92,6 +92,27 @@
         >
           <mat-icon>{{ hide ? 'visibility_off' : 'visibility' }}</mat-icon>
         </button>
+        <mat-error></mat-error>
+      </mat-form-field>
+      <br />
+
+      <!-- confirm-password -->
+      <mat-form-field>
+        <mat-label>confirm password</mat-label>
+        <input
+          [type]="hideConfirm ? 'password' : 'text'"
+          matInput
+          placeholder="confirm password"
+          id="confirmPassword"
+          formControlName="confirmPassword"
+          required
+        />
+        <button mat-icon-button matSuffix (click)="hideConfirm = !hideConfirm">
+          <mat-icon>{{
+            hideConfirm ? 'visibility_off' : 'visibility'
+          }}</mat-icon>
+        </button>
+        <mat-error></mat-error>
       </mat-form-field>
       <br />
 

--- a/src/app/create/create/create.component.html
+++ b/src/app/create/create/create.component.html
@@ -75,6 +75,7 @@
       <!-- password -->
       <mat-form-field>
         <mat-label>password</mat-label>
+        <mat-hint>8+ characters</mat-hint>
         <input
           type="hide ? 'password' : text"
           matInput

--- a/src/app/create/create/create.component.html
+++ b/src/app/create/create/create.component.html
@@ -64,8 +64,8 @@
           id="email"
           matInput
           placeholder="WorkOut123@example.com"
-          type="text"
-          autocomplete="off"
+          type="type"
+          autocomplete="email"
           required
         />
 

--- a/src/app/create/create/create.component.ts
+++ b/src/app/create/create/create.component.ts
@@ -11,6 +11,7 @@ import { FormBuilder, Validators, FormControl } from '@angular/forms';
 //   constructorの中に使いたい機能を定義
 export class CreateComponent implements OnInit {
   hide = true;
+  hideConfirm = true;
   form = this.fb.group({
     name: [
       '',

--- a/src/app/create/create/create.component.ts
+++ b/src/app/create/create/create.component.ts
@@ -10,6 +10,7 @@ import { FormBuilder, Validators, FormControl } from '@angular/forms';
 // ModuleでimportしたFormを画面上で使うためにComponentで定義するためにbuildして作る
 //   constructorの中に使いたい機能を定義
 export class CreateComponent implements OnInit {
+  hide = true;
   form = this.fb.group({
     name: [
       '',


### PR DESCRIPTION
確認用パスワードの入力フォームを追加しました。
確認お願いします。
<img width="151" alt="コメント 2020-04-16 142517" src="https://user-images.githubusercontent.com/60285013/79417848-28b33a80-7fee-11ea-8f33-970861865a31.png">
