### PR TITLE
feat(create): アカウント作成画面でのパスワードエラーハンドリング #34

### DIFF
--- a/src/app/create/create/create.component.html
+++ b/src/app/create/create/create.component.html
@@ -77,7 +77,7 @@
         <mat-label>password</mat-label>
         <mat-hint>8+ characters</mat-hint>
         <input
-          type="hide ? 'password' : text"
+          [type]="hide ? 'password' : 'text'"
           matInput
           placeholder="password"
           id="password"
@@ -96,7 +96,7 @@
         <mat-error *ngIf="passwordControl.hasError('required')"
           >You must enter a value</mat-error
         >
-        <mat-error *ngIf="passwordControl.hasError('minLength')"
+        <mat-error *ngIf="passwordControl.hasError('minlength')"
           >Password is short</mat-error
         >
       </mat-form-field>

--- a/src/app/create/create/create.component.html
+++ b/src/app/create/create/create.component.html
@@ -93,7 +93,12 @@
         >
           <mat-icon>{{ hide ? 'visibility_off' : 'visibility' }}</mat-icon>
         </button>
-        <mat-error></mat-error>
+        <mat-error *ngIf="passwordControl.hasError('required')"
+          >You must enter a value</mat-error
+        >
+        <mat-error *ngIf="passwordControl.hasError('minLength')"
+          >Password is short</mat-error
+        >
       </mat-form-field>
       <br />
 

--- a/src/app/create/create/create.component.ts
+++ b/src/app/create/create/create.component.ts
@@ -22,14 +22,17 @@ export class CreateComponent implements OnInit {
         Validators.maxLength(40)
       ]
     ],
-    gender: ['', [Validators.required, Validators.pattern(/male|female/)]]
+    gender: ['', [Validators.required, Validators.pattern(/male|female/)]],
+    password: ['', [Validators.required, Validators.minLength(8)]]
   });
 
   // エラーの内容を表示させる:create.html15,16
   get nameControl() {
     return this.form.get('name') as FormControl;
   }
-
+  get passwordControl() {
+    return this.form.get('password') as FormControl;
+  }
   // 開いたときに最初からエラーとして表示させる
   constructor(private fb: FormBuilder) {
     this.nameControl.markAsTouched();


### PR DESCRIPTION
・パスワード入力フォームに”入力してください”とのエラー表示
・パスワード入力フォームに8文字未満だと”短いです”とのエラー表示

確認お願いします。
<img width="97" alt="コメント 2020-04-21 125537" src="https://user-images.githubusercontent.com/60285013/79823766-74d7f380-83cf-11ea-93ce-4c7a615220da.png">
