### PR TITLE
feat(login): ログイン画面のメールアドレス、パスワード入力フォーム追加 #15

### DIFF
--- a/src/app/login/login.module.ts
+++ b/src/app/login/login.module.ts
@@ -2,23 +2,10 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LoginRoutingModule } from './login-routing.module';
 import { LoginComponent } from './login/login.component';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatButtonModule } from '@angular/material/button';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
+import { SharedModule } from '../shared/shared.module';
 
 @NgModule({
   declarations: [LoginComponent],
-  imports: [
-    CommonModule,
-    LoginRoutingModule,
-    ReactiveFormsModule,
-    FormsModule,
-    MatToolbarModule,
-    MatButtonModule,
-    MatFormFieldModule,
-    MatInputModule
-  ]
+  imports: [CommonModule, LoginRoutingModule, SharedModule]
 })
 export class LoginModule {}

--- a/src/app/login/login/login.component.html
+++ b/src/app/login/login/login.component.html
@@ -25,9 +25,46 @@
           matInput
           type="email"
           formControlName="email"
+          id="email"
+          placeholder="WorkOut123@example.com"
           autocomplete="email"
+          required
         />
-        <mat-error></mat-error>
+        <mat-error *ngIf="emailControl.hasError('required')"
+          >You must enter a value</mat-error
+        >
+        <mat-error *ngIf="emailControl.hasError('email')"
+          >Not a valid email</mat-error
+        >
+      </mat-form-field>
+      <br />
+
+      <mat-form-field>
+        <mat-label>password</mat-label>
+        <mat-hint>8+ characters</mat-hint>
+        <input
+          [type]="hide ? 'password' : 'text'"
+          matInput
+          placeholder="password"
+          id="password"
+          formControlName="password"
+          required
+        />
+        <button
+          mat-icon-button
+          matSuffix
+          (click)="hide = !hide"
+          [attr.aria-label]="'Hide password'"
+          [attr.aria-pressed]="hide"
+        >
+          <mat-icon>{{ hide ? 'visibility_off' : 'visibility' }}</mat-icon>
+        </button>
+        <mat-error *ngIf="passwordControl.hasError('required')"
+          >You must enter a value</mat-error
+        >
+        <mat-error *ngIf="passwordControl.hasError('minlength')"
+          >Password is short</mat-error
+        >
       </mat-form-field>
     </form>
   </div>

--- a/src/app/login/login/login.component.scss
+++ b/src/app/login/login/login.component.scss
@@ -43,3 +43,16 @@ mat-toolbar-row {
     left: 0;
   }
 }
+
+mat-form-field {
+  color: black;
+}
+
+mat-label {
+  color: white;
+}
+
+::placeholder {
+  color: white;
+  opacity: 0.6;
+}

--- a/src/app/login/login/login.component.ts
+++ b/src/app/login/login/login.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Validators, FormBuilder } from '@angular/forms';
+import { Validators, FormBuilder, FormControl } from '@angular/forms';
 import { AuthService } from 'src/app/services/auth.service';
 
 @Component({
@@ -8,10 +8,18 @@ import { AuthService } from 'src/app/services/auth.service';
   styleUrls: ['./login.component.scss']
 })
 export class LoginComponent implements OnInit {
+  hide = true;
   form = this.fb.group({
     email: ['', [Validators.email, Validators.required]],
-    password: ['', [Validators.required, Validators.minLength(6)]]
+    password: ['', [Validators.required, Validators.minLength(8)]]
   });
+
+  get emailControl() {
+    return this.form.get('email') as FormControl;
+  }
+  get passwordControl() {
+    return this.form.get('password') as FormControl;
+  }
 
   constructor(private fb: FormBuilder, private authService: AuthService) {}
 


### PR DESCRIPTION
・メールアドレス入力フォーム、エラーハンドリング追加
・パスワード入力フォーム、エラーハンドリング追加
・パスワードの表示on.offボタン追加

確認お願いします。
<img width="220" alt="コメント 2020-04-27 122217" src="https://user-images.githubusercontent.com/60285013/80331034-f1f8e200-8881-11ea-9376-83b18706fd10.png">
<img width="219" alt="コメント 2020-04-27 122138" src="https://user-images.githubusercontent.com/60285013/80331037-f32a0f00-8881-11ea-9625-a07fe442b28d.png">
<img width="219" alt="コメント 2020-04-27 122428" src="https://user-images.githubusercontent.com/60285013/80331128-2c627f00-8882-11ea-8ef2-4b298fef74e7.png">
