### PR TITLE
fix(404): 404ページUI修正 #145

### DIFF
--- a/src/app/not-found/not-found.component.html
+++ b/src/app/not-found/not-found.component.html
@@ -1,11 +1,14 @@
 <div class="wrapper">
-  <mat-toolbar class="header" color="primary">
-    <mat-toolbar-row>
-      <a routerLink="/" class="header-logo">Work Out</a>
-    </mat-toolbar-row>
-  </mat-toolbar>
-
   <div class="container">
-    <img src="/assets/images/404.png" alt="404image" />
+    <div class="container__top">
+      <div class="container__img">
+        <img src="/assets/images/404.png" alt="404image" />
+      </div>
+      <div class="container__back">
+        <button routerLink="/" mat-stroked-button>
+          HOME
+        </button>
+      </div>
+    </div>
   </div>
 </div>

--- a/src/app/not-found/not-found.component.scss
+++ b/src/app/not-found/not-found.component.scss
@@ -4,14 +4,15 @@
   }
 }
 
-.header-logo {
-  color: white;
-  display: block;
-  text-decoration: none;
+.wrapper {
+  height: 100%;
+  width: 100%;
+  text-align: center;
+  align-items: center;
+  justify-content: center;
+  display: flex;
 }
-
 img {
-  margin-top: 50px;
   @include sp {
     width: 240px;
   }


### PR DESCRIPTION
 - 全体の見た目を上下中央に配置
 - homeに戻るボタン追加

お手数お掛けしますが、ご確認の程よろしく御願い致します。

![スクリーンショット 2021-03-05 17 38 35](https://user-images.githubusercontent.com/60285013/110089593-a4220400-7dd9-11eb-8c0c-fff57cf82a4e.png)
