### PR TITLE
fix(postdialog): postdialogFB修正 #184

### DIFF
--- a/src/app/post-dialog/post-dialog.component.html
+++ b/src/app/post-dialog/post-dialog.component.html
@@ -32,7 +32,7 @@
       <mat-icon>perm_media</mat-icon>
     </button>
     <div class="actions__icon">
-      <button mat-raised-button matDialogClose>Cancel</button>
+      <button mat-stroked-button matDialogClose>Cancel</button>
       <button
         class="actions__post"
         mat-raised-button

--- a/src/app/post-dialog/post-dialog.component.scss
+++ b/src/app/post-dialog/post-dialog.component.scss
@@ -8,6 +8,7 @@
   }
   &__forms {
     text-align: center;
+    height: 245px;
   }
   &__form {
     width: 95%;
@@ -17,7 +18,7 @@
     font-size: 11px;
     color: rgba(0, 0, 0, 0.4);
     text-align: right;
-    margin: 0 0 34px;
+    margin: 0 0 60px;
   }
 }
 


### PR DESCRIPTION
- キャンセルボタンの修正
- 文字数カウントの位置修正

![スクリーンショット 2021-03-25 17 04 56](https://user-images.githubusercontent.com/60285013/112439334-57a06780-8d8c-11eb-86f1-ec4ba869f15e.png)

![スクリーンショット 2021-03-25 17 05 34](https://user-images.githubusercontent.com/60285013/112439353-5cfdb200-8d8c-11eb-8785-fefd469bd546.png)


お手数お掛けしますが、ご確認のほどよろしくお願い致します。